### PR TITLE
Streams refactor

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ const clientMovePointer$ = clientConnected$
 const clientDisconnected$ = clientConnected$
   .flatMap((client) =>
     Rx.Observable.fromEvent(client, 'disconnect')
-      .map((client) => ({
+      .map(() => ({
         type: 'USER_DISCONNECTED',
         id: client.id
       }))

--- a/server.js
+++ b/server.js
@@ -4,7 +4,6 @@ const express = require('express')
 const app = express()
 const server = require('http').Server(app)
 const io = require('socket.io')(server)
-
 const Rx = require('rx')
 
 const port = 3000

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const express = require('express')
 const app = express()
 const server = require('http').Server(app)
 const io = require('socket.io')(server)
+
 const Rx = require('rx')
 
 const port = 3000
@@ -14,31 +15,29 @@ server.listen(port, function () {
   console.log(`Server started in port ${port}`)
 })
 
-const client$ = Rx.Observable.create((observer) => {
-  io.on('connection', (client) => observer.onNext(client))
-})
+const clientConnected$ = Rx.Observable.fromEvent(io, 'connection')
 
-const clientMovePointer$ = client$
-  .flatMap((client) => Rx.Observable.create((observer) =>
-    client.on('pointer-move', (pointerData) => {
-      const action = { type: 'POINTER_MOVE', pointerData }
-      observer.onNext(action)
-    }))
-  )
+const clientMovePointer$ = clientConnected$
+  .flatMap((client) => Rx.Observable.fromEvent(client, 'pointer-move'))
+  .map((pointerData) => ({
+    type: 'POINTER_MOVE',
+    pointerData
+  }))
 
-const clientDisconnects$ = client$
-  .flatMap((client) => Rx.Observable.create((observer) =>
-    client.on('disconnect', () => {
-      const action = { type: 'USER_DISCONNECTED', id: client.id }
-      observer.onNext(action)
-    }))
+const clientDisconnected$ = clientConnected$
+  .flatMap((client) =>
+    Rx.Observable.fromEvent(client, 'disconnect')
+      .map((client) => ({
+        type: 'USER_DISCONNECTED',
+        id: client.id
+      }))
   )
 
 // Since it's not being managed with immutable structures, it looks ugly, but it works :)
 const stateManager$ =
   Rx.Observable.merge(
     clientMovePointer$,
-    clientDisconnects$
+    clientDisconnected$
   )
   .scan(function dirtyReducer (acc, action) {
     switch (action.type) {


### PR DESCRIPTION
Refactor to remove `Rx.Observable.create` from the socket streams.